### PR TITLE
feat: add support for VXE R1 Pro (PID 0xf58a)

### DIFF
--- a/battery_tray.pyw
+++ b/battery_tray.pyw
@@ -395,6 +395,7 @@ class BatteryTrayApp:
             
             last_recv_time = time.time()
             last_trim_time = time.time()
+            last_feat_time = 0
             while self.running:
                 if time.time() - last_trim_time > 60:
                     trim_memory()
@@ -414,6 +415,8 @@ class BatteryTrayApp:
                     self.current_model = model_check
                     last_recv_time = time.time()
                     
+                got_passive = False
+                read_failed = False
                 try:
                     data = dev.read(64)
                     if data:
@@ -453,9 +456,28 @@ class BatteryTrayApp:
                             if 0 <= battery <= 100:
                                 self.update_battery_level(battery, charging=is_dock_charging)
                                 last_recv_time = time.time()
-                    time.sleep(0.1)
+                                got_passive = True
                 except OSError:
+                    read_failed = True
+
+                # Feature report 0x06 query fallback for VXE / CompX NordicMouse devices
+                if not got_passive and (time.time() - last_feat_time >= 2.0):
+                    last_feat_time = time.time()
+                    try:
+                        f_data = dev.get_feature_report(0x06, 65)
+                        if f_data and len(f_data) >= 4 and f_data[0] == 0x06:
+                            is_dock_charging = bool(f_data[2])
+                            battery = f_data[3]
+                            if 0 <= battery <= 100:
+                                self.update_battery_level(battery, charging=is_dock_charging)
+                                last_recv_time = time.time()
+                    except Exception:
+                        pass
+
+                if read_failed and self.last_battery < 0 and (time.time() - last_recv_time > 10):
                     break
+
+                time.sleep(0.1)
                     
             dev.close()
         except OSError:

--- a/devices.py
+++ b/devices.py
@@ -49,9 +49,11 @@ SUPPORTED_DEVICES = {
 
     # VXE R1 Series (R1 / SE / SE+) (Thanks to @nzeck1)
     (0x3554, 0xf58e): ("VXE R1 Series", "wireless"),
+    (0x3554, 0xf58a): ("VXE R1 Series", "wireless"),
     (0x320f, 0x5055): ("VXE R1 Series", "wireless"),
     (0x3537, 0x2106): ("VXE R1 Series", "wireless"),
     0xf58e: ("VXE R1 Series", "wireless"),
+    0xf58a: ("VXE R1 Series", "wireless"),
     0x5055: ("VXE R1 Series", "wireless"),
     0x2106: ("VXE R1 Series", "wireless"),
 
@@ -218,7 +220,7 @@ def find_device_path() -> Tuple[Optional[str], Optional[str], Optional[str]]:
 
             item = (d['path'], mode, model_name)
 
-            if if_num == 2 and usage_page == 10:
+            if (if_num == 2 and usage_page == 10) or usage_page == 0xff04:
                 p1_match = item
                 break  # Perfect match — no need to scan further
             elif (usage_page == 10 or usage_page >= 0xff00 or if_num == 2) and p2_match is None:

--- a/dump_devices.py
+++ b/dump_devices.py
@@ -18,7 +18,7 @@ def get_mouse_devices():
             continue
             
         prod_lower = prod.lower()
-        is_relevant_brand = vid in [0x1d57, 0x25a7, 0x3710, 0x258a, 0x0c45, 0x093a, 0x24ae, 0x1bcf, 0x046d, 0x1532]
+        is_relevant_brand = vid in [0x1d57, 0x25a7, 0x3710, 0x258a, 0x0c45, 0x093a, 0x24ae, 0x1bcf, 0x046d, 0x1532, 0x3554, 0x320f, 0x3537, 0x3770]
         is_generic_input = any(term in prod_lower for term in ["mouse", "keyboard", "wireless", "receiver", "dongle", "usb", "hid"])
         
         if is_relevant_brand or is_generic_input:


### PR DESCRIPTION
## Summary
Adds battery reading support for the **VXE R1 Pro** (`VID 0x3554`, `PID 0xf58a`).

## Changes
- **`devices.py`**:
  - Registered `(0x3554, 0xf58a)` and `0xf58a` under `SUPPORTED_DEVICES` for `"VXE R1 Series"`.
  - Updated `find_device_path()` to prioritize `usage_page == 0xff04` alongside `(if_num == 2 and usage_page == 10)`.
- **`battery_tray.pyw`**:
  - Added Feature Report `0x06` fallback polling for CompX / VXE NordicMouse devices on Windows when direct HID `dev.read()` returns an `OSError` on feature-only endpoints.
- **`dump_devices.py`**:
  - Added `0x3554`, `0x320f`, `0x3537`, `0x3770` (CompX / VXE VIDs) to `is_relevant_brand` so future `dump_devices.py` scans automatically detect VXE and CompX devices.

## Verification
- Validated on hardware with VXE R1 Pro (`0x3554:0xf58a`).
- Confirmed correct battery level reporting (100% / connected status).
